### PR TITLE
return the rule seperately

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,6 +2,7 @@ import json
 import re
 import logging
 from SublimeLinter.lint import NodeLinter
+from SublimeLinter.lint.linter import LintMatch
 
 logger = logging.getLogger('SublimeLinter.plugin.stylelint')
 
@@ -62,8 +63,14 @@ class Stylelint(NodeLinter):
             for warning in data['warnings']:
                 line = warning['line'] - self.line_col_base[0]
                 col = warning['column'] - self.line_col_base[1]
-                severity = warning['severity']
-                rule = warning['rule']
-                text = warning['text'].replace('(' + rule + ')', '')
+                text = warning['text'].replace('(' + warning['rule'] + ')', '')
+                text = text.rstrip()
 
-                yield (warning, line, col, rule, severity, text, None)
+                yield LintMatch(
+                    match=warning,
+                    line=line,
+                    col=col,
+                    error_type=warning['severity'],
+                    code=warning['rule'],
+                    message=text
+                )

--- a/linter.py
+++ b/linter.py
@@ -62,10 +62,8 @@ class Stylelint(NodeLinter):
             for warning in data['warnings']:
                 line = warning['line'] - self.line_col_base[0]
                 col = warning['column'] - self.line_col_base[1]
-                type = warning['severity']
-                text = warning['text']
+                severity = warning['severity']
+                rule = warning['rule']
+                text = warning['text'].replace('(' + rule + ')', '')
 
-                if type == 'warning':
-                    yield (warning, line, col, "", type, text, None)
-                else:
-                    yield (warning, line, col, type, "", text, None)
+                yield (warning, line, col, rule, severity, text, None)


### PR DESCRIPTION
This change makes find_errors always yield the same data, specifically noting the rule and severity. The text property repeats the rule so we remove it here.

<img width="633" alt="screenshot 2019-02-27 at 12 12 13" src="https://user-images.githubusercontent.com/2543659/53486417-ef85d700-3a88-11e9-9807-643e10156d45.png">
