### PR TITLE
Add sugarss support

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Stylelint(NodeLinter):
     )
 
     defaults = {
-        'selector': 'source.css - meta.attribute-with-value, source.sass, source.scss, source.less'  # noqa 501
+        'selector': 'source.css - meta.attribute-with-value, source.sass, source.scss, source.less, source.sss'  # noqa 501
     }
 
     def find_errors(self, output):


### PR DESCRIPTION
Adds support for [sugarss](https://github.com/postcss/sugarss), assuming it is configured as a parser in `.postcssrc`

[Syntax highlighting](https://github.com/aazcast/Syntax-SugarSS-SublimeText)